### PR TITLE
feat: image can be blacklisted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+images

--- a/script.py
+++ b/script.py
@@ -4,24 +4,38 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin
 import mimetypes
 
+backlistImages = ["snippet-banner-image.png"]
+
+
+def check_blacklist_images(url):
+    for image in backlistImages:
+        if image in url:
+            return True
+        else:
+            return False
+
+
 def fetch_page_content(url):
     response = requests.get(url)
     response.raise_for_status()
     return response.text
 
+
 def get_h1_text(soup):
-    h1_tag = soup.find('h1')
+    h1_tag = soup.find("h1")
     h1_text = h1_tag.get_text() if h1_tag else "no_h1"
-    return h1_text.strip().replace(' ', '_').replace('/', '_').replace('\\', '_')
+    return h1_text.strip().replace(" ", "_").replace("/", "_").replace("\\", "_")
+
 
 def download_image(img_url, img_filename):
     img_data = requests.get(img_url).content
-    with open(img_filename, 'wb') as handler:
+    with open(img_filename, "wb") as handler:
         handler.write(img_data)
     print(f"Downloaded {img_filename}")
 
+
 def find_and_download_images(div_content, url, h1_text, output_dir):
-    images = div_content.find_all('img')
+    images = div_content.find_all("img")
     if not images:
         print("No images found in the 'toc-content' div.")
         return
@@ -32,39 +46,49 @@ def find_and_download_images(div_content, url, h1_text, output_dir):
 
     idx = 1
     for img in images:
-        img_url = img.get('src')
-        if not img_url.startswith('http'):
+        img_url = img.get("src")
+        if not img_url.startswith("http"):
             img_url = urljoin(url, img_url)
 
-        if img_url.endswith('.svg'):
+        if img_url.endswith(".svg"):
             print(f"Skipping SVG image: {img_url}")
             continue
 
-        content_type = requests.head(img_url).headers.get('content-type')
-        if 'svg' in content_type:
+        content_type = requests.head(img_url).headers.get("content-type")
+        if "svg" in content_type:
             print(f"Skipping SVG image: {img_url}")
             continue
 
-        extension = mimetypes.guess_extension(content_type) or '.jpg'
-        img_filename = os.path.join(output_dir, f'{h1_text}_image_{idx}{extension}')
-        download_image(img_url, img_filename)
-        idx += 1
+        extension = mimetypes.guess_extension(content_type) or ".jpg"
+        img_filename = os.path.join(output_dir, f"{h1_text}_image_{idx}{extension}")
+        # if src contain snippet-banner-image.png
+        if check_blacklist_images(img_url):
+            print(f"Image is blacklisted: {img_url}")
+        else:
+            download_image(img_url, img_filename)
+            idx += 1
+
 
 def download_main_image(soup, url, h1_text, output_dir):
-    main_image_div = soup.find('div', class_="w-full border-2 border-heading rounded-[20px] md:rounded-[40px] m-0 overflow-hidden min-h-[200px] md:min-h-[350px] lg:min-h-[500px]")
-    
+    main_image_div = soup.find(
+        "div",
+        class_="w-full border-2 border-heading rounded-[20px] md:rounded-[40px] m-0 overflow-hidden min-h-[200px] md:min-h-[350px] lg:min-h-[500px]",
+    )
+
     if main_image_div:
-        img_tag = main_image_div.find('img')
+        img_tag = main_image_div.find("img")
         if img_tag:
-            img_url = img_tag.get('src')
+            img_url = img_tag.get("src")
             full_img_url = urljoin(url, img_url)
 
-            if full_img_url.endswith('.svg'):
+            if full_img_url.endswith(".svg"):
                 print(f"Skipping SVG image: {full_img_url}")
                 return
 
-            img_filename = os.path.join(output_dir, f'{h1_text}_image_main{os.path.splitext(full_img_url)[1]}')
-            
+            img_filename = os.path.join(
+                output_dir, f"{h1_text}_image_main{os.path.splitext(full_img_url)[1]}"
+            )
+
             try:
                 download_image(full_img_url, img_filename)
             except Exception as e:
@@ -74,9 +98,10 @@ def download_main_image(soup, url, h1_text, output_dir):
     else:
         print("No main image div found on the page.")
 
+
 def scrape_toc_content(url):
     page_content = fetch_page_content(url)
-    soup = BeautifulSoup(page_content, 'html.parser')
+    soup = BeautifulSoup(page_content, "html.parser")
 
     h1_text = get_h1_text(soup)
     output_dir = os.path.join("images", f"{h1_text}")
@@ -85,14 +110,15 @@ def scrape_toc_content(url):
 
     download_main_image(soup, url, h1_text, output_dir)
 
-    div_content = soup.find('div', class_='toc-content')
+    div_content = soup.find("div", class_="toc-content")
     if div_content:
         print(f"Scraping content from: {url}")
         find_and_download_images(div_content, url, h1_text, output_dir)
     else:
         print("No <div> with class 'toc-content' found.")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import sys
 
     if len(sys.argv) != 2:


### PR DESCRIPTION
Now we can blacklist some certain images, like snippet-banner-image.png, it is on big cta, which is auto filled, we don't need its image. Also update the gitignore for images folder.